### PR TITLE
Fixed a language issue

### DIFF
--- a/ez-conf-lib
+++ b/ez-conf-lib
@@ -54,6 +54,7 @@ EOF
 ########################################################################
 # make sure the system talks basic English
 export LANG=C
+export LC_ALL=C
 
 ########################################################################
 # ocaml/system constants


### PR DESCRIPTION
The `LANG=C` fix is not sufficient on its own to resolve the language bug. This should fix the problem for more peoples. At least, it fixed the issue on my machine.

For more context, I switched languages at some point, but I forgot to change all locale files, so my OS is in English, but my GCC is in another language.